### PR TITLE
Fallback to tag duration to when calculating progress

### DIFF
--- a/src/player/store.ts
+++ b/src/player/store.ts
@@ -87,6 +87,7 @@ export const playerModule: Module<State, any> = {
       state.scrobbled = false
       const track = state.queue[index]
       audio.src = track.url
+      state.duration = track.duration
       document.title = `${track.title} • ${track.artist}`
       if (mediaSession) {
         mediaSession.metadata = new MediaMetadata({
@@ -250,16 +251,20 @@ export function setupAudio(store: Store<any>, api: API) {
     store.commit('player/setCurrentTime', audio.currentTime)
 
     // Scrobble
-    if (store.state.player.scrobbled === false &&
-        audio.duration > 30 &&
-        audio.currentTime / audio.duration > 0.7) {
+    if (
+      store.state.player.scrobbled === false &&
+      store.state.player.duration > 30 &&
+      audio.currentTime / store.state.player.duration > 0.7
+    ) {
       const id = store.getters['player/trackId']
       store.commit('player/setScrobbled')
       api.scrobble(id)
     }
   }
   audio.ondurationchange = () => {
-    store.commit('player/setDuration', audio.duration)
+    if (isFinite(audio.duration)) {
+      store.commit('player/setDuration', audio.duration)
+    }
   }
   audio.onerror = () => {
     store.commit('player/setPaused')


### PR DESCRIPTION
hey, I've written a subsonic server called gonic and a user of it reported that airsonic-refix's progress bar doesn't progress when it's streaming a track that the server is currently transcoding

I had a look at some other subsonic clients and they seem to fallback to the track's duration tag instead if it's not available 

this PR attempts to implement that (please note it's not very well tested at all)
is it something you would be interested in?

thanks!

issue: https://github.com/sentriz/gonic/issues/128