### PR TITLE
small fix to prevent JS error from displaying when no track is loaded

### DIFF
--- a/src/player/Player.vue
+++ b/src/player/Player.vue
@@ -44,7 +44,7 @@
               <b-button title="Favourite"
                         variant="link" class="m-0"
                         @click="toggleFavourite">
-                <Icon :icon="track.favourite ? 'heart-fill' : 'heart'" />
+                <Icon :icon="track && track.favourite ? 'heart-fill' : 'heart'" />
               </b-button>
               <b-button id="player-volume-btn" variant="link" title="Volume">
                 <Icon :icon="muteActive ? 'volume-mute-fill' : 'volume-up-fill'" />


### PR DESCRIPTION
It might be better to use a `v-if` or something else (I am a complete Vue novice), but this at least prevents the error from being shown.