### PR TITLE
build/push docker images for arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,35 @@ jobs:
           name: dist
           path: dist
 
-      - name: Build docker image
-        run: docker build -t $IMAGE:$VERSION -f docker/Dockerfile .
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=sha,format=long
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
 
-      - name: Push docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker push $IMAGE:$VERSION
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          file: docker/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   preview:
     runs-on: ubuntu-latest
@@ -90,14 +111,3 @@ jobs:
         with:
           args: deploy --dir=dist --prod
 
-  publish_latest_docker_image:
-    runs-on: ubuntu-latest
-    needs: build_docker_image
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Push latest
-        run: |
-          docker pull $IMAGE:$VERSION
-          docker tag $IMAGE:$VERSION $IMAGE:latest
-          docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker push $IMAGE:latest


### PR DESCRIPTION
Hi,

this change modifies your github actions workflow to build docker images for multiple architectures (fixes #18).

`docker build` is replaced by `docker buildx build`, which supports setting a `--platform` parameter to set the architecture.
In your case no cross-compilation is needed, since the `dist/` folder you copy into the image is just javascript and therefore platform independent.
The base image `nginx:alpine` is already a multi-arch image, so in the end buildx will just switch out the base image with the one for the specific architecture. 