### PR TITLE
Playlist: expose and allow setting "public" field

### DIFF
--- a/src/library/playlist/Playlist.vue
+++ b/src/library/playlist/Playlist.vue
@@ -12,8 +12,8 @@
         </ContextMenuItem>
       </OverflowMenu>
     </div>
-    <p v-if="playlist.comment" class="text-muted">
-      {{ playlist.comment }}
+    <p v-if="playlist.isPublic || playlist.comment" class="text-muted">
+      {{ playlist.comment | prependPublic(playlist.isPublic) }}
     </p>
     <TrackList v-if="playlist.tracks.length > 0" :tracks="playlist.tracks">
       <template #context-menu="{index}">
@@ -36,6 +36,12 @@
         <div class="form-group">
           <label>Comment</label>
           <textarea v-model="item.comment" class="form-control" />
+        </div>
+        <div class="form-group">
+          <label>
+            <input v-model="item.isPublic" type="checkbox">
+            Public
+          </label>
         </div>
       </template>
     </EditModal>
@@ -62,6 +68,11 @@
       return {
         playlist: null as any,
         showEditModal: false,
+      }
+    },
+    filters: {
+      prependPublic: function(value: string, isPublic: boolean) {
+        return isPublic ? '[Public] ' + value : value
       }
     },
     watch: {

--- a/src/library/playlist/store.ts
+++ b/src/library/playlist/store.ts
@@ -17,12 +17,13 @@ export const usePlaylistStore = defineStore('playlist', {
         this.playlists = orderBy(result, 'createdAt')
       })
     },
-    async update({ id, name, comment }: Playlist) {
+    async update({ id, name, comment, isPublic }: Playlist) {
       const playlist = this.playlists?.find(x => x.id === id)
       if (playlist) {
         playlist.name = name
         playlist.comment = comment
-        await this.api.editPlaylist(id, name, comment)
+        playlist.isPublic = isPublic
+        await this.api.editPlaylist(id, name, comment, isPublic)
       }
     },
     async addTracks(playlistId: string, trackIds: string[]) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -77,6 +77,7 @@ export interface Playlist {
   id: string
   name: string
   comment: string
+  isPublic: boolean
   trackCount: number
   createdAt: string
   updatedAt: string
@@ -234,11 +235,12 @@ export class API {
     return this.getPlaylists()
   }
 
-  async editPlaylist(playlistId: string, name: string, comment: string) {
+  async editPlaylist(playlistId: string, name: string, comment: string, isPublic: boolean) {
     const params = {
       playlistId,
       name,
       comment,
+      public: isPublic,
     }
     await this.fetch('rest/updatePlaylist', params)
   }
@@ -453,6 +455,7 @@ export class API {
       updatedAt: response.changed || '',
       trackCount: response.songCount,
       image: response.songCount > 0 ? this.getCoverArtUrl(response) : undefined,
+      isPublic: response.public,
     }
   }
 


### PR DESCRIPTION
Hi there! This update allows setting the "public" property of playlists. It adds a "[Public]" tag where the playlist comment goes, here's some screenshots of the changes:

New checkbox and label in the edit modal:

![Edit Modal](https://github.com/tamland/airsonic-refix/assets/4265148/91805a3e-4bd0-440f-b2ae-521abb7582af)

A playlist with no comment, and it's not public (no change):

![No Comment, Not Public](https://github.com/tamland/airsonic-refix/assets/4265148/f5e94864-012e-4624-ad18-d4354147d9e0)

A playlist with a comment, still not public (no change):

![Comment, Not Public](https://github.com/tamland/airsonic-refix/assets/4265148/b434b047-557c-40e4-85b4-8c42d6b6e31b)

A public playlist without a comment (new):

![No Comment, Public](https://github.com/tamland/airsonic-refix/assets/4265148/db574297-5216-4473-8548-5cfcae2e2d90)

A public playlist with a comment (new):

![Comment, Public](https://github.com/tamland/airsonic-refix/assets/4265148/fbc8ade8-14cc-4106-b297-cfe80445383d)
