### PR TITLE
don't truncate outlines of the contents of Hero

### DIFF
--- a/src/shared/components/Hero.vue
+++ b/src/shared/components/Hero.vue
@@ -3,7 +3,7 @@
     <div class="backdrop" />
     <img v-if="image" :src="image">
     <img v-else src="@/shared/assets/fallback.svg">
-    <div class="body d-flex flex-column pt-4 pt-md-0 pl-md-4 text-center text-md-left">
+    <div class="body d-flex flex-column pt-4 pt-md-0 pl-md-4 pb-1 text-center text-md-left">
       <slot />
     </div>
   </div>


### PR DESCRIPTION
the :focus outline of the Play / Shuffle is truncated since Hero has overflow-y: auto;

since we need the overflow, this just adds a pb-1 so we always see the focus state

before:
![Screen Shot 2023-09-27 at 20 29 42](https://github.com/tamland/airsonic-refix/assets/6832539/93147bc0-b33f-498e-afda-661e257c8aa5)
after:
![Screen Shot 2023-09-27 at 20 29 28](https://github.com/tamland/airsonic-refix/assets/6832539/cb61e5e5-a0a6-4fc6-93e4-183275c2e2d7)
