### PR TITLE
add ReplayGain support

### DIFF
--- a/src/player/Player.vue
+++ b/src/player/Player.vue
@@ -68,6 +68,13 @@
                         :value="volume" @input="setVolume"
                 />
               </b-popover>
+              <b-button title="ReplayGain"
+                        variant="link" class="m-0"
+                        @click="toggleReplayGain">
+                <IconReplayGain v-if="replayGainMode === ReplayGainMode.None" />
+                <IconReplayGainTrack v-else-if="replayGainMode === ReplayGainMode.Track" />
+                <IconReplayGainAlbum v-else-if="replayGainMode === ReplayGainMode.Album" />
+              </b-button>
               <b-button title="Shuffle"
                         variant="link" class="m-0" :class="{ 'text-primary': shuffleActive }"
                         @click="toggleShuffle">
@@ -127,21 +134,29 @@
 </template>
 <script lang="ts">
   import { defineComponent } from 'vue'
+  import { ReplayGainMode } from './audio'
   import ProgressBar from '@/player/ProgressBar.vue'
   import { useFavouriteStore } from '@/library/favourite/store'
   import { formatArtists } from '@/shared/utils'
   import { BPopover } from 'bootstrap-vue'
   import SwitchInput from '@/shared/components/SwitchInput.vue'
+  import IconReplayGain from '@/shared/components/IconReplayGain.vue'
+  import IconReplayGainTrack from '@/shared/components/IconReplayGainTrack.vue'
+  import IconReplayGainAlbum from '@/shared/components/IconReplayGainAlbum.vue'
 
   export default defineComponent({
     components: {
       SwitchInput,
       BPopover,
       ProgressBar,
+      IconReplayGain,
+      IconReplayGainTrack,
+      IconReplayGainAlbum,
     },
     setup() {
       return {
         favouriteStore: useFavouriteStore(),
+        ReplayGainMode,
       }
     },
     computed: {
@@ -153,6 +168,9 @@
       },
       isMuted() {
         return this.$store.state.player.volume <= 0.0
+      },
+      replayGainMode(): ReplayGainMode {
+        return this.$store.state.player.replayGainMode
       },
       repeatActive(): boolean {
         return this.$store.state.player.repeat
@@ -200,6 +218,9 @@
       },
       setVolume(volume: any) {
         return this.$store.dispatch('player/setVolume', parseFloat(volume))
+      },
+      toggleReplayGain() {
+        return this.$store.dispatch('player/toggleReplayGain')
       },
       setPlaybackRate(value: number) {
         return this.$store.dispatch('player/setPlaybackRate', value)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -23,7 +23,8 @@ export interface Track {
   isStream?: boolean
   isPodcast?: boolean
   isUnavailable?: boolean
-  playCount? : number
+  playCount?: number
+  replayGain?: {trackGain: number, trackPeak: number, albumGain: number, albumPeak: number}
 }
 
 export interface Genre {
@@ -541,6 +542,7 @@ export class API {
         : [{ id: item.artistId, name: item.artist }],
       url: this.getStreamUrl(item.id),
       image: this.getCoverArtUrl(item),
+      replayGain: item.replayGain,
     }
   }
 

--- a/src/shared/components/IconReplayGain.vue
+++ b/src/shared/components/IconReplayGain.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" role="img" focusable="false" aria-hidden="true"
+       width="1em" height="1em" fill="currentColor"
+       viewBox="0 0 24 24"
+       class="icon bi">
+    <text opacity="0.5" x="0" y="50%" dominant-baseline="central" text-anchor="start" font-family="Arial, sans-serif" font-weight="bold" font-size="16" fill="currentColor">RG</text>
+  </svg>
+</template>

--- a/src/shared/components/IconReplayGainAlbum.vue
+++ b/src/shared/components/IconReplayGainAlbum.vue
@@ -1,0 +1,9 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" role="img" focusable="false" aria-hidden="true"
+       width="1em" height="1em" fill="currentColor"
+       viewBox="0 0 24 24"
+       class="icon bi">
+    <text x="0" y="50%" dominant-baseline="central"  font-family="Arial, sans-serif" font-weight="bold" font-size="16" fill="currentColor">R</text>
+    <text x="52%" y="72%" dominant-baseline="central" font-family="Arial, sans-serif" font-weight="bold" font-size="13" fill="currentColor">A</text>
+  </svg>
+</template>

--- a/src/shared/components/IconReplayGainTrack.vue
+++ b/src/shared/components/IconReplayGainTrack.vue
@@ -1,0 +1,9 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" role="img" focusable="false" aria-hidden="true"
+       width="1em" height="1em" fill="currentColor"
+       viewBox="0 0 24 24"
+       class="icon bi">
+    <text x="0" y="50%" dominant-baseline="central"  font-family="Arial, sans-serif" font-weight="bold" font-size="16" fill="currentColor">R</text>
+    <text x="52%" y="72%" dominant-baseline="central" font-family="Arial, sans-serif" font-weight="bold" font-size="13" fill="currentColor">T</text>
+  </svg>
+</template>


### PR DESCRIPTION
Add a quick toggle to choose between 

- no ReplayGain
- album level ReplayGain (nice when you're listening to many albums, preserving the dynamic range of each)
- track level ReplayGain (nice if you're listing to a mixed playlist)

ReplayGain 2.0 is specfifed here https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification

Settings are only applied if a valid [`replayGain`](https://opensubsonic.netlify.app/docs/responses/replaygain/) object in the `song` response 

https://github.com/user-attachments/assets/6a6b2120-e947-47ec-92ab-24b23f713056