### PR TITLE
ReplayGain: make sure volume doesn't exceed 1.0

### DIFF
--- a/src/player/audio.ts
+++ b/src/player/audio.ts
@@ -172,7 +172,7 @@ export class AudioController {
           return
         }
         const elapsed = Date.now() - startTime
-        this.audio.volume = clamp(0.0, Math.max(from, to), from + (elapsed * step))
+        this.audio.volume = clamp(0.0, Math.min(Math.max(from, to), 1), from + (elapsed * step))
         this.handle = setTimeout(run, 10)
       }
       run()


### PR DESCRIPTION
sometimes the clamp will result in this.audio.volume being slightly >1 which throws an exception since it must be in the range 0-1 https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume

i think this happens if the peak volume calcuation is slightly off in the tags. since most of the time when when this happens for me it's trying to set it to soemthing like 1.012323