### PR TITLE
Group albums by type in ArtistDetails

### DIFF
--- a/src/library/artist/ArtistDetails.vue
+++ b/src/library/artist/ArtistDetails.vue
@@ -66,28 +66,20 @@
       <TrackList :tracks="item.topTracks" no-artist />
     </template>
 
-    <template v-if="albums.length > 0">
-      <div class="d-flex justify-content-between mt-5 mb-2">
+    <template v-for="({ releaseType, albums: releaseTypeAlbums }) in albums">
+      <div :key="releaseType" class="d-flex justify-content-between mt-5 mb-2">
         <h3 class="my-0">
-          Albums
+          {{ releaseType }}
         </h3>
         <b-button variant="link" class="p-0" @click="toggleAlbumSortOrder">
           <Icon icon="arrow-up-down" />
         </b-button>
       </div>
-      <div v-for="({ releaseType, albums: releaseTypeAlbums }) in albums" :key="releaseType">
-        <template v-if="albums.length >= 2">
-          <h4 class="mt-3 text-muted">
-            {{ releaseType }}
-          </h4>
-          <hr class="my-2">
+      <AlbumList :key="releaseType" :items="releaseTypeAlbums">
+        <template #text="{ year }">
+          {{ year || 'Unknown' }}
         </template>
-        <AlbumList :items="releaseTypeAlbums">
-          <template #text="{ year }">
-            {{ year || 'Unknown' }}
-          </template>
-        </AlbumList>
-      </div>
+      </AlbumList>
     </template>
 
     <template v-if="item.similarArtist.length > 0">
@@ -143,7 +135,7 @@
       albums(): { releaseType: string, albums: Album[] }[] {
         const sorted: Album[] = (orderBy(this.item?.albums ?? [], 'year', this.mainStore.artistAlbumSortOrder) || [])
         const grouped = Object.groupBy(sorted, ({ isCompilation, releaseTypes }) =>
-          isCompilation ? 'Compilation' : (releaseTypes[0] || 'Other')
+          isCompilation ? 'Compilation' : (releaseTypes[0] || 'Album')
         ) || {}
 
         const groupOrder = ['Album', 'EP', 'Single']

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -48,6 +48,8 @@ export interface Album {
   lastFmUrl?: string
   musicBrainzUrl?: string
   tracks?: Track[]
+  isCompilation: boolean
+  releaseTypes: string[]
 }
 
 export interface Artist {
@@ -591,7 +593,9 @@ export class API {
       musicBrainzUrl: item.musicBrainzId
         ? `https://musicbrainz.org/release/${item.musicBrainzId}`
         : undefined,
-      tracks: (item.song || []).map(this.normalizeTrack, this)
+      tracks: (item.song || []).map(this.normalizeTrack, this),
+      isCompilation: !!item.isCompilation,
+      releaseTypes: item.releaseTypes.length ? item.releaseTypes : [],
     }
   }
 


### PR DESCRIPTION
Renders albums on the artist page in categories such as (Single, Album, EP, Compilation, etc)

Based on [OpenSubsonic AlbumID3](https://opensubsonic.netlify.app/docs/responses/albumid3/)

Note: For backwards compatibility, groups are not shown when there is only one group type (which will be Unknown when not present in response)

Groups are sorted in order Album, EP, Single. then anything after (Compilation, Other) comes later

![image](https://github.com/user-attachments/assets/d3efae5f-0c8c-44fa-b89d-d32e2b752638)
![Screen Shot 2025-07-07 at 22 21 53](https://github.com/user-attachments/assets/d3168d9f-b855-4ea3-869d-e3c438e66894)

