### PR TITLE
fixes for Android

### DIFF
--- a/src/player/audio.ts
+++ b/src/player/audio.ts
@@ -64,6 +64,7 @@ export class AudioController {
   }
 
   async resume() {
+    await this.context.resume()
     await this.pipeline.audio.play()
     await this.fadeIn()
   }
@@ -128,9 +129,7 @@ export class AudioController {
       this.statsListener?.start()
     }
 
-    if (options.isStream) {
-      this.pipeline.audio.load()
-    }
+    this.pipeline.audio.load()
 
     if (options.paused !== true) {
       try {


### PR DESCRIPTION
New Audiocontroler does not work on Android, at least with Vivaldi browser and Brave on my Pixel 8.

-> "this.pipeline.audio.load()" is required for some browser, so it should not be conditioned by isStream

-> resume() should resume context : call "await this.context.resume()"

