### PR TITLE
Rootless container

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Environment variables:
 
 - `SERVER_URL` (Optional): The backend server URL. When set the server input on the login page will not be displayed.
 
+#### Rootless Docker
+
+The container image also supports running with additional security measures, such as read-only rootfs:
+
+```shell
+docker run --read-only --cap-drop ALL \
+  --tmpfs /tmp:noexec,nosuid,size=100m \
+  --detach --publish 8080:8080 \
+  --volume app:/app tamland/airsonic-refix:latest
+```
+
 ### Pre-built bundle
 
 Pre-built bundles can be found in the [Actions](https://github.com/tamland/airsonic-refix/actions)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Modern responsive web frontend for [airsonic-advanced](https://github.com/airson
 [gonic](https://github.com/sentriz/gonic) and other [subsonic](https://github.com/topics/subsonic) compatible music servers.
 
 ## Features
+
 - Responsive UI for desktop and mobile
 - Browse library for albums, artist, genres
 - Playback with persistent queue, repeat & shuffle
@@ -22,16 +23,15 @@ Modern responsive web frontend for [airsonic-advanced](https://github.com/airson
 
 Enter the URL and credentials for your subsonic compatible server, or use one of the following public demo servers:
 
-**Subsonic**  
-  Server: `https://airsonic-refix.netlify.app/api`  
-  Username: `guest4`, `guest5`, `guest6` etc.  
-  Password:`guest`
+**Subsonic**
+Server: `https://airsonic-refix.netlify.app/api`
+Username: `guest4`, `guest5`, `guest6` etc.
+Password:`guest`
 
-**Navidrome**  
-  Server: `https://demo.navidrome.org`  
-  Username: `demo`  
-  Password:`demo`
-
+**Navidrome**
+Server: `https://demo.navidrome.org`
+Username: `demo`
+Password:`demo`
 
 **Note**: if the server is using http only you must allow mixed content in your browser otherwise login will not work.
 
@@ -49,15 +49,15 @@ Enter the URL and credentials for your subsonic compatible server, or use one of
 
 ### Docker
 
-```
-$ docker run -d -p 8080:80 tamland/airsonic-refix:latest
+```shell
+docker run --detach --publish 8080:8080 tamland/airsonic-refix:latest
 ```
 
 You can now access the application at http://localhost:8080/
 
 Environment variables:
-- `SERVER_URL` (Optional): The backend server URL. When set the server input on the login page will not be displayed.
 
+- `SERVER_URL` (Optional): The backend server URL. When set the server input on the login page will not be displayed.
 
 ### Pre-built bundle
 
@@ -66,24 +66,24 @@ tab. Download/extract artifact and serve with any web server such as nginx or ap
 
 ### Build from source
 
-```
-$ yarn install
-$ yarn build
+```shell
+yarn install
+yarn build
 ```
 
 Bundle can be found in the `dist` folder.
 
 Build docker image:
 
-```
-$ docker build -f docker/Dockerfile .
+```shell
+docker build -f docker/Dockerfile .
 ```
 
 ## Develop
 
-```
-$ yarn install
-$ yarn dev
+```shel
+yarn install
+yarn dev
 ```
 
 ## OpenSubsonic support

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,28 @@
+# syntax=docker/dockerfile:1
 FROM nginx:alpine
 
-EXPOSE 80
+EXPOSE 8080
 
-RUN apk add gettext
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
-COPY docker/env.js.template /env.js.template
-COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
-COPY dist/ /var/www/html/
+RUN apk --no-cache add gettext
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["nginx", "-g", "daemon off;"]
+# Setup an unprivileged user
+RUN mkdir -p /app /resources/nginx
+
+RUN addgroup -g 1000 appgroup && \
+    adduser -D -u 1000 -G appgroup appuser
+RUN chown -R appuser:appgroup /app
+
+COPY docker/nginx.conf /resources/nginx.conf
+COPY docker/nginx-app.conf /resources/nginx/app.conf
+
+COPY docker/env.js.template /resources/env.js.template
+COPY --chmod=755 docker/docker-entrypoint.sh /resources/docker-entrypoint.sh
+
+USER appuser
+COPY --chown=appuser:appgroup dist/ /app/
+
+# Allows mounting a volume that retains the app (when read-only rootfs)
+VOLUME /app
+
+ENTRYPOINT ["/resources/docker-entrypoint.sh"]
+CMD ["nginx", "-c", "/resources/nginx.conf", "-g", "daemon off;"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-envsubst < env.js.template > /var/www/html/env.js
+envsubst < /resources/env.js.template > /app/env.js
 exec "$@"

--- a/docker/nginx-app.conf
+++ b/docker/nginx-app.conf
@@ -1,0 +1,24 @@
+gzip on;
+gzip_proxied any;
+gzip_vary on;
+gzip_buffers 16 8k;
+gzip_types *;
+
+server {
+  listen 8080;
+  server_name localhost;
+  root /app;
+
+  location / {
+    root /app;
+    try_files $uri /index.html;
+  }
+
+  location = /index.html {
+    add_header 'Cache-Control' 'no-cache';
+  }
+
+  location = /env.js {
+    add_header 'Cache-Control' 'no-cache';
+  }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,24 +1,36 @@
-gzip on;
-gzip_proxied any;
-gzip_vary on;
-gzip_buffers 16 8k;
-gzip_types *;
+worker_processes  auto;
 
-server {
-  listen 80;
-  server_name localhost;
-  root /var/www/html;
+# required when running unprivileged
+pid /tmp/nginx.pid;
 
-  location / {
-    root /var/www/html;
-    try_files $uri /index.html;
-  }
+events {
+    worker_connections  1024;
+}
 
-  location = /index.html {
-    add_header 'Cache-Control' 'no-cache';
-  }
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
 
-  location = /env.js {
-    add_header 'Cache-Control' 'no-cache';
-  }
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /dev/stdout main;
+    error_log  /dev/stderr info;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    # required when running unprivileged
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    include /resources/nginx/*.conf;
 }


### PR DESCRIPTION
This PR converts the nginx installation to be run as an unprivileged user, also known as a rootless container. Additional enhancements has been added that allows the user to run with a read-only rootfs as well as add a volume for the appdir (read-write).