### PR TITLE
player: don't update progress when page is not focused

### DIFF
--- a/src/player/store.ts
+++ b/src/player/store.ts
@@ -244,6 +244,7 @@ export const usePlayerStore = defineStore('player', {
 
 export function setupAudio(playerStore: ReturnType<typeof usePlayerStore>, mainStore: ReturnType<typeof useMainStore>, api: API) {
   audio.ontimeupdate = (value: number) => {
+    if (document.hidden) return
     playerStore.currentTime = value
   }
   audio.ondurationchange = (value: number) => {


### PR DESCRIPTION
Fixes an issue where on Firefox, airsonic-refix uses ~50% CPU when playing a track. Even when not focused.

The issue lies somewhere in the progress bar being updated from ontimeupdate

Looking at a profile:

	RefreshDriver tick (70%) -> Update the rendering paint (55%) -> Paint (54%)

Chrome seems not have the issue, maybe it's internally throttling when not focused.

For Firefox, just not updating the store when the document is hidden dropped usage down to 8% from 50% for me

<img width="705" height="432" alt="image" src="https://github.com/user-attachments/assets/639ff94d-a6f7-46e1-8bc8-e086cabbaab6" />
