### PR TITLE
player: reduce CPU usage by disabling progress bar animation

### DIFF
--- a/src/player/ProgressBar.vue
+++ b/src/player/ProgressBar.vue
@@ -5,6 +5,7 @@
     :min="0"
     :max="1"
     :interval="0.00001"
+    :duration="0"
     :lazy="true"
     :contained="true"
     :dot-options="{tooltip: 'always'}"


### PR DESCRIPTION
vue-slider-component has a default transition animation duration of 0.5s, which causes repaint each frame.
https://github.com/NightCatSama/vue-slider-component/blob/master/lib/vue-slider.tsx#L107
Setting VueSlider duration to zero disable the animation, visually this almost doesn't change anything.

Tested on Firefox and Chrome:
- Before: repaints every frame (~10ms on my machine)
- After: repaints only on audio.ontimeupdate events (~250ms on my machine)

@sentriz can you check if this is better ?