### PR TITLE
fix: invalidate cached playlists views when adding tracks

### DIFF
--- a/src/library/playlist/Playlist.vue
+++ b/src/library/playlist/Playlist.vue
@@ -106,6 +106,11 @@
         showEditModal: false,
       }
     },
+    computed: {
+      lastChanged() {
+        return this.playlistStore.playlists?.find(p => p.id === this.id)?.updatedAt || ''
+      }
+    },
     watch: {
       id: {
         immediate: true,
@@ -114,6 +119,15 @@
           this.$api.getPlaylist(value).then(playlist => {
             this.playlist = playlist
           })
+        }
+      },
+      lastChanged: {
+        handler() {
+          if (this.playlist) {
+            this.$api.getPlaylist(this.id).then(playlist => {
+              this.playlist = playlist
+            })
+          }
         }
       }
     },


### PR DESCRIPTION
Route views are cached by the `<keep-alive>` in `src/app/App.vue`. When navigating between a playlist view and an album view to add songs to the playlist this means that I often get shown an outdated playlist state where the added songs don't show up in the playlist view. This PR fixes that by refreshing the playlist based on the `lastChanged` attribute in the `playlistStore`.