### PR TITLE
Add support for multi-disc albums

### DIFF
--- a/src/library/album/AlbumDetails.vue
+++ b/src/library/album/AlbumDetails.vue
@@ -69,7 +69,7 @@
     </Hero>
     <div class="row">
       <div class="col">
-        <TrackList :tracks="album.tracks" :disc-titles="album.discTitles" :disc-image="album.image" no-album />
+        <TrackList :tracks="album.tracks" :disc-titles="album.discTitles" :disc-image="album.image" group-by-disc no-album />
       </div>
     </div>
   </div>

--- a/src/library/album/AlbumDetails.vue
+++ b/src/library/album/AlbumDetails.vue
@@ -69,7 +69,7 @@
     </Hero>
     <div class="row">
       <div class="col">
-        <TrackList :tracks="album.tracks" no-album />
+        <TrackList :tracks="album.tracks" :disc-titles="album.discTitles" :disc-image="album.image" no-album />
       </div>
     </div>
   </div>

--- a/src/library/track/TrackList.vue
+++ b/src/library/track/TrackList.vue
@@ -84,6 +84,7 @@
       tracks: { type: Array as PropType<Track[]>, required: true },
       discTitles: { type: Array as PropType<DiscTitle[]>, default: () => [] },
       discImage: { type: String, default: undefined },
+      groupByDisc: { type: Boolean, default: false },
       noAlbum: { type: Boolean, default: false },
       noArtist: { type: Boolean, default: false },
       noDuration: { type: Boolean, default: false },
@@ -101,7 +102,7 @@
         return this.playerStore.trackId
       },
       isMultiDisc(): boolean {
-        return new Set(this.tracks.map(track => track.discNumber ?? 1)).size > 1
+        return this.groupByDisc && new Set(this.tracks.map(track => track.discNumber ?? 1)).size > 1
       },
       columnCount(): number {
         return 3 + Number(!this.noArtist) + Number(!this.noAlbum) + Number(!this.noDuration)

--- a/src/library/track/TrackList.vue
+++ b/src/library/track/TrackList.vue
@@ -12,22 +12,47 @@
       </th>
     </BaseTableHead>
     <tbody>
-      <tr v-for="(item, index) in tracks" :key="index"
-          :class="{'active': item.id === playingTrackId}"
-          :draggable="true" @dragstart="dragstart(item, $event)"
-          @click="play(index)">
-        <CellTrackNumber
-          :active="item.id === playingTrackId && isPlaying"
-          :value="item.track || index + 1"
-        />
-        <CellTitle :track="item" />
-        <CellArtist v-if="!noArtist" :track="item" />
-        <CellAlbum v-if="!noAlbum" :track="item" />
-        <CellDuration v-if="!noDuration" :track="item" />
-        <CellActions :track="item">
-          <slot name="context-menu" :index="index" :item="item" />
-        </CellActions>
-      </tr>
+      <template v-for="(item, index) in tracks">
+        <tr v-if="isMultiDisc && isFirstTrackOfDisc(index)" :key="`disc-${discNumber(item)}`" class="disc-heading">
+          <td />
+          <td :colspan="columnCount - 1">
+            <div class="d-flex align-items-center gap-3">
+              <img
+                v-if="discImageFor(item)"
+                :src="discImageFor(item)"
+                :alt="`${discLabel(item)} cover art`"
+                class="rounded object-fit-cover"
+                width="72"
+                height="72"
+              >
+              <div>
+                <div v-if="discTitleFor(item)?.title" class="text-muted">
+                  Disc {{ discNumber(item) }}
+                </div>
+                <h2 class="h5 mb-0">
+                  {{ discLabel(item) }}
+                </h2>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr :key="item.id"
+            :class="{'active': item.id === playingTrackId}"
+            :draggable="true" @dragstart="dragstart(item, $event)"
+            @click="play(index)">
+          <CellTrackNumber
+            :active="item.id === playingTrackId && isPlaying"
+            :value="trackNumber(item, index)"
+          />
+          <CellTitle :track="item" />
+          <CellArtist v-if="!noArtist" :track="item" />
+          <CellAlbum v-if="!noAlbum" :track="item" />
+          <CellDuration v-if="!noDuration" :track="item" />
+          <CellActions :track="item">
+            <slot name="context-menu" :index="index" :item="item" />
+          </CellActions>
+        </tr>
+      </template>
     </tbody>
   </BaseTable>
 </template>
@@ -41,7 +66,7 @@
   import CellTitle from '@/library/track/CellTitle.vue'
   import BaseTable from '@/library/track/BaseTable.vue'
   import BaseTableHead from '@/library/track/BaseTableHead.vue'
-  import { Track } from '@/shared/api'
+  import { DiscTitle, Track } from '@/shared/api'
   import { usePlayerStore } from '@/player/store'
 
   export default defineComponent({
@@ -57,6 +82,8 @@
     },
     props: {
       tracks: { type: Array as PropType<Track[]>, required: true },
+      discTitles: { type: Array as PropType<DiscTitle[]>, default: () => [] },
+      discImage: { type: String, default: undefined },
       noAlbum: { type: Boolean, default: false },
       noArtist: { type: Boolean, default: false },
       noDuration: { type: Boolean, default: false },
@@ -73,8 +100,40 @@
       playingTrackId() {
         return this.playerStore.trackId
       },
+      isMultiDisc(): boolean {
+        return new Set(this.tracks.map(track => track.discNumber ?? 1)).size > 1
+      },
+      columnCount(): number {
+        return 3 + Number(!this.noArtist) + Number(!this.noAlbum) + Number(!this.noDuration)
+      },
     },
     methods: {
+      discNumber(track: Track): number {
+        return track.discNumber ?? 1
+      },
+      discTitleFor(track: Track): DiscTitle | undefined {
+        const discNumber = this.discNumber(track)
+        return this.discTitles.find(({ disc }) => disc === discNumber)
+      },
+      discLabel(track: Track): string {
+        return this.discTitleFor(track)?.title || `Disc ${this.discNumber(track)}`
+      },
+      discImageFor(track: Track): string | undefined {
+        return this.discTitleFor(track)?.image || this.discImage
+      },
+      isFirstTrackOfDisc(index: number): boolean {
+        return index === 0 || this.discNumber(this.tracks[index - 1]) !== this.discNumber(this.tracks[index])
+      },
+      trackNumber(track: Track, index: number): number {
+        if (track.track) {
+          return track.track
+        }
+        const discNumber = this.discNumber(track)
+        while (index > 0 && this.discNumber(this.tracks[index - 1]) === discNumber) {
+          index--
+        }
+        return this.tracks.indexOf(track) - index + 1
+      },
       play(index: number) {
         if (this.tracks[index].id === this.playingTrackId) {
           return this.playerStore.playPause()
@@ -89,3 +148,9 @@
     }
   })
 </script>
+<style scoped>
+  .disc-heading {
+    --bs-table-hover-bg: transparent;
+    cursor: default !important;
+  }
+</style>

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -17,6 +17,7 @@ export interface Track {
   image?: string
   url?: string
   track?: number
+  discNumber?: number
   album?: string
   albumId?: string
   artists: {name: string, id: string}[]
@@ -36,6 +37,12 @@ export interface Genre {
   name: string
 }
 
+export interface DiscTitle {
+  disc: number
+  title: string
+  image?: string
+}
+
 export interface Album {
   id: string
   name: string
@@ -48,6 +55,7 @@ export interface Album {
   lastFmUrl?: string
   musicBrainzUrl?: string
   tracks?: Track[]
+  discTitles?: DiscTitle[]
   releaseType?: string
 }
 
@@ -560,6 +568,7 @@ export class API {
       duration: item.duration,
       favourite: !!item.starred,
       track: item.track,
+      discNumber: item.discNumber,
       album: item.album,
       albumId: item.albumId,
       artists: item.artists?.length
@@ -598,6 +607,11 @@ export class API {
         ? `https://musicbrainz.org/release/${item.musicBrainzId}`
         : undefined,
       tracks: (item.song || []).map(this.normalizeTrack, this),
+      discTitles: (item.discTitles || []).map((disc: {disc: number, title: string, coverArt?: string}): DiscTitle => ({
+        disc: disc.disc,
+        title: disc.title,
+        image: this.getCoverArtUrl(disc),
+      })),
       releaseType: this.normalizeReleaseType(item),
     }
   }


### PR DESCRIPTION
Uses the data from navidrome to make multi-disc albums more legible

This only appears on multi-disc albums. Discs with title `Disc N` are shown only with `Disc N`. Discs with a custom name have a heading showing the disc number, like in the second screenshot.

Before:
<img width="2510" height="1470" alt="CleanShot 2026-07-17 at 14 52 00@2x" src="https://github.com/user-attachments/assets/c8219279-488c-481f-afc5-6c29d188a4a6" />

After:
<img width="2510" height="1476" alt="CleanShot 2026-07-17 at 14 52 10@2x" src="https://github.com/user-attachments/assets/b8bf6d7f-99e3-4824-8910-38bcf81ece24" />
